### PR TITLE
Additional Chance Clipping Fix

### DIFF
--- a/When the Crow Sings/Assets/Art/Characters/Chance/src/char_Chance.fbx
+++ b/When the Crow Sings/Assets/Art/Characters/Chance/src/char_Chance.fbx
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a53c7be4df8b658ff2f4b81de71f67946906270eaacf75322d92ccfa47df4cb8
-size 3060780
+oid sha256:2c38674f06587cbc6b88b3429f4b7e6e2481da7bafab67035e5b9dd0a07172e7
+size 2924492


### PR DESCRIPTION
Fixed the clipping you see after Chance releases the bird seed from the aim anim into the throw anim by further adjusting the vertex grouping of the undershirt.