### PR TITLE
NPC Tweaks

### DIFF
--- a/When the Crow Sings/Assets/Art/Characters/Angel/pf_Angel.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Angel/pf_Angel.prefab
@@ -25,8 +25,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 597394058382247996}
   serializedVersion: 2
-  m_LocalRotation: {x: -0.2979433, y: -0.00016316773, z: 0.000018879773, w: -0.9545836}
-  m_LocalPosition: {x: 48.76111, y: 4.924675, z: -39.994644}
+  m_LocalRotation: {x: -0.14271362, y: 0.7932845, z: -0.20374934, w: -0.5557147}
+  m_LocalPosition: {x: 5.3545184, y: 5.22097, z: 3.4627323}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -301,6 +301,41 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 5650799973319839335}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.6118706
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.013458727
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.0650537
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.73335195
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.0000000036464427
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.11717218
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Beau/pf_Beau.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Beau/pf_Beau.prefab
@@ -297,6 +297,56 @@ PrefabInstance:
       propertyPath: walkSpeed
       value: 2
       objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Height
+      value: 6.7605753
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.9292965
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.0000000010026058
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 2.4682431
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.13084483
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Height
+      value: 6.428408
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.8629189
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.3962452
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 2.6753843
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.062078718
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Caleb/pf_Caleb.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Caleb/pf_Caleb.prefab
@@ -461,27 +461,47 @@ PrefabInstance:
     - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Radius
-      value: 1.1123325
+      value: 1.5102023
       objectReference: {fileID: 0}
     - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Center.x
-      value: -0.006484866
+      value: -0.22376633
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 1.9999709
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0.03948021
       objectReference: {fileID: 0}
     - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Radius
-      value: 1.2957627
+      value: 1.501984
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Center.x
-      value: -0.19251192
+      value: 0.013709545
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 1.9999843
       objectReference: {fileID: 0}
     - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Center.z
-      value: 0
+      value: 7.842688e-12
       objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}

--- a/When the Crow Sings/Assets/Art/Characters/Caleb/src/AC_Caleb.controller
+++ b/When the Crow Sings/Assets/Art/Characters/Caleb/src/AC_Caleb.controller
@@ -204,7 +204,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.9803459
   m_HasExitTime: 0
@@ -286,7 +286,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.89406776
   m_HasExitTime: 0

--- a/When the Crow Sings/Assets/Art/Characters/Farida/pf_Farida.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Farida/pf_Farida.prefab
@@ -63,6 +63,21 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 1178461340417668804}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.4703664
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.052337766
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0.100069284
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Francisco/pf_Francisco.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Francisco/pf_Francisco.prefab
@@ -202,6 +202,41 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 3704799833089545553}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.3652909
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.075067274
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -8.926976e-11
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.6119572
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.070803046
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.0000000011713769
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Francisco/src/AC_Francisco.controller
+++ b/When the Crow Sings/Assets/Art/Characters/Francisco/src/AC_Francisco.controller
@@ -73,7 +73,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.97540987
   m_HasExitTime: 0
@@ -126,7 +126,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.97769517
   m_HasExitTime: 0

--- a/When the Crow Sings/Assets/Art/Characters/Jazmyne/pf_Jazmyne.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Jazmyne/pf_Jazmyne.prefab
@@ -181,6 +181,36 @@ PrefabInstance:
       propertyPath: WaypointsHolders.Array.size
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.4610653
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.0029945374
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.07704103
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.84271884
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.34271884
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Jazmyne/src/AC_Jazmyne.controller
+++ b/When the Crow Sings/Assets/Art/Characters/Jazmyne/src/AC_Jazmyne.controller
@@ -71,7 +71,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.91549295
   m_HasExitTime: 0
@@ -316,7 +316,7 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0.75
   m_TransitionOffset: 0
   m_ExitTime: 0.91549295
   m_HasExitTime: 0

--- a/When the Crow Sings/Assets/Art/Characters/Philomena/pf_Philomena.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Philomena/pf_Philomena.prefab
@@ -340,6 +340,46 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 6051546383318122527}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.3330151
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.034447193
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 4.7922066e-10
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.3433853
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.044772625
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.046889786
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_IsTrigger
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Quinn/pf_Quinn.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Quinn/pf_Quinn.prefab
@@ -218,6 +218,41 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 5190316821844787921}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.8072113
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.009384388
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0.110255964
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.5501563
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.0000000016048103
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 0.026712717
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Quinn/src/AC_Quinn.controller
+++ b/When the Crow Sings/Assets/Art/Characters/Quinn/src/AC_Quinn.controller
@@ -17,9 +17,9 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 1
   m_TransitionOffset: 0
-  m_ExitTime: 0.89830506
+  m_ExitTime: 0.8845023
   m_HasExitTime: 0
   m_HasFixedDuration: 1
   m_InterruptionSource: 0

--- a/When the Crow Sings/Assets/Art/Characters/Theo/pf_Theo.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Theo/pf_Theo.prefab
@@ -63,6 +63,31 @@ PrefabInstance:
       propertyPath: animator
       value: 
       objectReference: {fileID: 4410584427497488783}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 1.3672612
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.01618886
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.59024787
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.025219202
+      objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Name

--- a/When the Crow Sings/Assets/Art/Characters/Yule/pf_Yule.prefab
+++ b/When the Crow Sings/Assets/Art/Characters/Yule/pf_Yule.prefab
@@ -596,6 +596,41 @@ PrefabInstance:
       propertyPath: m_LocalPosition.y
       value: 4.54
       objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.12563449
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.99206793
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.004148777
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0.00000001862645
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 194.435
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0.06199646
+      objectReference: {fileID: 0}
+    - target: {fileID: 293881171247267887, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: -0.4869995
+      objectReference: {fileID: 0}
     - target: {fileID: 399671171280927328, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -653,18 +688,33 @@ PrefabInstance:
       objectReference: {fileID: 8782941424237076698}
     - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
+      propertyPath: m_Height
+      value: 5.125335
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
       propertyPath: m_Radius
-      value: 1.61
+      value: 2.5626676
       objectReference: {fileID: 0}
     - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Center.x
-      value: 4.7025318e-12
+      value: 0.01947689
+      objectReference: {fileID: 0}
+    - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 1.9999975
       objectReference: {fileID: 0}
     - target: {fileID: 3291438220563399179, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}
       propertyPath: m_Center.z
-      value: 0.012598514
+      value: 0.22427486
+      objectReference: {fileID: 0}
+    - target: {fileID: 5340269627348009014, guid: b5f8242a87cb047419b4cf20ef6758c3,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 6163397890752162378, guid: b5f8242a87cb047419b4cf20ef6758c3,
         type: 3}

--- a/When the Crow Sings/Assets/Scenes/INTERIORS/EnergyHQ/EnergyHQ_ADD_Morning.unity
+++ b/When the Crow Sings/Assets/Scenes/INTERIORS/EnergyHQ/EnergyHQ_ADD_Morning.unity
@@ -503,8 +503,18 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1137721504396159707, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137721504396159707, guid: 9a8fc1e250134694db5c2cf299839c50,
+        type: 3}
       propertyPath: m_Intensity
-      value: 250
+      value: 200
+      objectReference: {fileID: 0}
+    - target: {fileID: 1137721504396159707, guid: 9a8fc1e250134694db5c2cf299839c50,
+        type: 3}
+      propertyPath: m_SpotAngle
+      value: 44.100777
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
@@ -524,22 +534,22 @@ PrefabInstance:
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7237755
+      value: 0.71154046
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.41198796
+      value: 0.4637924
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.08853352
+      value: -0.15937586
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.5464218
+      value: -0.5031959
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
@@ -549,7 +559,7 @@ PrefabInstance:
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: -41.89
+      value: -53.193
       objectReference: {fileID: 0}
     - target: {fileID: 3561910493830820900, guid: 9a8fc1e250134694db5c2cf299839c50,
         type: 3}

--- a/When the Crow Sings/Assets/Scenes/INTERIORS/EnergyHQ/EnergyHQ_LVL.unity
+++ b/When the Crow Sings/Assets/Scenes/INTERIORS/EnergyHQ/EnergyHQ_LVL.unity
@@ -484,6 +484,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5043838451863394929, guid: 7a6f08f061ff8cc4f8550cb02beb26bc,
+        type: 3}
+      propertyPath: m_Radius
+      value: 0.5631556
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043838451863394929, guid: 7a6f08f061ff8cc4f8550cb02beb26bc,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043838451863394929, guid: 7a6f08f061ff8cc4f8550cb02beb26bc,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 0.019168615
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043838451863394929, guid: 7a6f08f061ff8cc4f8550cb02beb26bc,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -1.14748516e-10
+      objectReference: {fileID: 0}
     - target: {fileID: 5110214104092786416, guid: 7a6f08f061ff8cc4f8550cb02beb26bc,
         type: 3}
       propertyPath: virtualCamera

--- a/When the Crow Sings/Assets/Scenes/Zone2/Zone2_LVL.unity
+++ b/When the Crow Sings/Assets/Scenes/Zone2/Zone2_LVL.unity
@@ -5858,6 +5858,26 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 925383732}
     m_Modifications:
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 284.7239
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 14.127719
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 32.183563
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -61.383095
+      objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -7902,6 +7922,26 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 925383732}
     m_Modifications:
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 276.3516
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 14.127724
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 32.183544
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -65.5692
+      objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -12139,6 +12179,26 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 925383732}
     m_Modifications:
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 233.55016
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 14.127724
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 32.183544
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -86.96998
+      objectReference: {fileID: 0}
     - target: {fileID: 7132312558388933576, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -12162,7 +12222,7 @@ PrefabInstance:
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 28.041428
+      value: 22.17
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
@@ -12172,42 +12232,42 @@ PrefabInstance:
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -135.1291
+      value: -129.77
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.7071068
+      value: 0.7095414
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.7071068
+      value: -0.7046378
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: 0.005239564
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: 0.0030463366
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
+      value: -89.566
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: 24.433
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
+      value: -23.762
       objectReference: {fileID: 0}
     - target: {fileID: 8789878631938380317, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
@@ -13211,6 +13271,31 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 925383732}
     m_Modifications:
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 585.9342
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 268.00818
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.x
+      value: 14.127743
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 32.183563
+      objectReference: {fileID: 0}
+    - target: {fileID: 5034082566139570441, guid: 281359f3be560fd45a8d4453faeefa1c,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -69.740944
+      objectReference: {fileID: 0}
     - target: {fileID: 7132312558388933576, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_Materials.Array.data[0]
@@ -13234,7 +13319,7 @@ PrefabInstance:
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 26.201427
+      value: 20.329998
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
@@ -13244,7 +13329,7 @@ PrefabInstance:
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -133.6891
+      value: -128.33
       objectReference: {fileID: 0}
     - target: {fileID: 8264172004614834343, guid: 281359f3be560fd45a8d4453faeefa1c,
         type: 3}

--- a/When the Crow Sings/Assets/Scenes/Zone3/Zone3_LVL.unity
+++ b/When the Crow Sings/Assets/Scenes/Zone3/Zone3_LVL.unity
@@ -3694,6 +3694,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 769171542}
     m_Modifications:
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1291.1583
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 168.62988
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 773.99036
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -7.2568007
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -60.61101
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 386.49506
+      objectReference: {fileID: 0}
     - target: {fileID: 785565642086135931, guid: cc13b9215fdcb3b45af03ec0cf367f36,
         type: 3}
       propertyPath: m_Size.x
@@ -3793,36 +3823,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 355.314
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1291.1583
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 168.62988
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.z
-      value: 773.99036
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.x
-      value: -7.2568007
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.y
-      value: -60.61101
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 386.49506
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4221,6 +4221,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 954297072}
     m_Modifications:
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 4.747816
+      objectReference: {fileID: 0}
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 0.830866
+      objectReference: {fileID: 0}
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 4.572035
+      objectReference: {fileID: 0}
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -0.12609172
+      objectReference: {fileID: 0}
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Center.y
+      value: 0.08456718
+      objectReference: {fileID: 0}
+    - target: {fileID: 31064139356493631, guid: 35b74c7f74ca291449788b1db10a6c06,
+        type: 3}
+      propertyPath: m_Center.z
+      value: -0.014390469
+      objectReference: {fileID: 0}
     - target: {fileID: 92131338825748303, guid: 35b74c7f74ca291449788b1db10a6c06,
         type: 3}
       propertyPath: m_LocalScale.x
@@ -15873,6 +15903,33 @@ MeshFilter:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 569850390}
   m_Mesh: {fileID: -3658208960273339047, guid: 50692bbe5c2dba1468b7ca49ca46df16, type: 3}
+--- !u!1 &572605474 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2665379537608341536, guid: 5806a9c0a9753604abe3f92a27b22b61,
+    type: 3}
+  m_PrefabInstance: {fileID: 1098542342}
+  m_PrefabAsset: {fileID: 0}
+--- !u!65 &572605478
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 572605474}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.55143327, y: 3.452408, z: 0.34963128}
+  m_Center: {x: 0.000004181743, y: 0.00021793104, z: 0.2628604}
 --- !u!1001 &583440976
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -16119,6 +16176,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalRotation.z
       value: 0.020778706
+      objectReference: {fileID: 0}
+    - target: {fileID: 5043838451863394929, guid: fbaf48a2d3590c54eac488b56fdb2e98,
+        type: 3}
+      propertyPath: m_Enabled
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 5558097263909396274, guid: fbaf48a2d3590c54eac488b56fdb2e98,
         type: 3}
@@ -17262,6 +17324,31 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 769171542}
     m_Modifications:
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 190.07472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 773.99066
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -7.2567463
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -71.33574
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 386.49515
+      objectReference: {fileID: 0}
     - target: {fileID: 785565642086135931, guid: cc13b9215fdcb3b45af03ec0cf367f36,
         type: 3}
       propertyPath: m_Size.x
@@ -17356,31 +17443,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 205.792
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 190.07472
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.z
-      value: 773.99066
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.x
-      value: -7.2567463
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.y
-      value: -71.33574
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 386.49515
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -27428,6 +27490,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1661035674}
     m_Modifications:
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1291.1583
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 168.62988
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 773.99036
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -7.2568007
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -60.61101
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 386.49506
+      objectReference: {fileID: 0}
     - target: {fileID: 785565642086135931, guid: cc13b9215fdcb3b45af03ec0cf367f36,
         type: 3}
       propertyPath: m_Size.x
@@ -27512,36 +27604,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 340.025
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1291.1583
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 168.62988
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.z
-      value: 773.99036
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.x
-      value: -7.2568007
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.y
-      value: -60.61101
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 386.49506
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -29908,37 +29970,37 @@ PrefabInstance:
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -75.07754
+      value: -75.40138
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.58586335
+      value: -0.5900469
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -14.041415
+      value: -10.168044
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.75609404
+      value: -0.8704569
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.4885756
+      value: 0.45669547
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.43194708
+      value: -0.023714116
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.055113323
+      value: 0.18213154
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
@@ -29948,7 +30010,7 @@ PrefabInstance:
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 436
+      value: 379.643
       objectReference: {fileID: 0}
     - target: {fileID: 5734096587632751724, guid: 5806a9c0a9753604abe3f92a27b22b61,
         type: 3}
@@ -29959,7 +30021,11 @@ PrefabInstance:
     - {fileID: 2033316322992567059, guid: 5806a9c0a9753604abe3f92a27b22b61, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 2665379537608341536, guid: 5806a9c0a9753604abe3f92a27b22b61,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 572605478}
   m_SourcePrefab: {fileID: 100100000, guid: 5806a9c0a9753604abe3f92a27b22b61, type: 3}
 --- !u!4 &1098542343 stripped
 Transform:
@@ -32300,6 +32366,31 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1661035674}
     m_Modifications:
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 190.07472
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 773.99066
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -7.2567463
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -71.33574
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 386.49515
+      objectReference: {fileID: 0}
     - target: {fileID: 785565642086135931, guid: cc13b9215fdcb3b45af03ec0cf367f36,
         type: 3}
       propertyPath: m_Size.x
@@ -32379,31 +32470,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 228.864
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 190.07472
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.z
-      value: 773.99066
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.x
-      value: -7.2567463
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.y
-      value: -71.33574
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 386.49515
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -39009,6 +39075,36 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 1661035674}
     m_Modifications:
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.x
+      value: 1291.1583
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.y
+      value: 168.62988
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Size.z
+      value: 773.99036
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.x
+      value: -7.2568007
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.y
+      value: -60.61101
+      objectReference: {fileID: 0}
+    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
+        type: 3}
+      propertyPath: m_Center.z
+      value: 386.49506
+      objectReference: {fileID: 0}
     - target: {fileID: 785565642086135931, guid: cc13b9215fdcb3b45af03ec0cf367f36,
         type: 3}
       propertyPath: m_Size.x
@@ -39093,36 +39189,6 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 371.206
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.x
-      value: 1291.1583
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.y
-      value: 168.62988
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Size.z
-      value: 773.99036
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.x
-      value: -7.2568007
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.y
-      value: -60.61101
-      objectReference: {fileID: 0}
-    - target: {fileID: 5219144284727772713, guid: fd1fb44a7ecaf124d8f646dd9513fa37,
-        type: 3}
-      propertyPath: m_Center.z
-      value: 386.49506
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []


### PR DESCRIPTION
Expanded colliders on all npc's to avoid unexpected intimacy and clipping. Slightly adjusted Yules vision cone so he is still looking at Chance when he is talking to him right in front of him. Slight collider changes in zone 2 and zone 3. Extended the length of the transitions from Idle to Talk and vice versa for Quinn, Caleb, Jazmyne, and Francisco. Slightly adjusted Morning light in EHQ.